### PR TITLE
Add a deploy rule for site deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ all:
 regenerative:
 	$(JEKYLL) build -s $(INPUT_FOLDER) -d $(OUTPUT_FOLDER) --watch
 
+deploy:
+	$(JEKYLL) serve --host=0.0.0.0 build -s $(INPUT_FOLDER) -d $(OUTPUT_FOLDER) --watch
+
 serve:
 	$(JEKYLL) serve build -s $(INPUT_FOLDER) -d $(OUTPUT_FOLDER) --watch


### PR DESCRIPTION
CHANGELOG

- Add a rule on the Makefile to allow the site to be _deployable_.

Signed-off-by: Rafael Campos Nunes <rafaelnunes@engineer.com>